### PR TITLE
Implement operations with the underlying primitive integer types.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.idea

--- a/src/int.rs
+++ b/src/int.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
 };
+use std::cmp::Ordering;
 
 #[cfg(feature = "serde")]
 use serde::{
@@ -513,6 +514,18 @@ impl PartialEq<Int> for i64 {
     }
 }
 
+impl PartialOrd<i64> for Int {
+    fn partial_cmp(&self, other: &i64) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<Int> for i64 {
+    fn partial_cmp(&self, other: &Int) -> Option<Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
 impl Neg for Int {
     type Output = Self;
 
@@ -690,7 +703,12 @@ mod tests {
 
     #[test]
     fn comparing_int_to_i64() {
+        // equality
         assert_eq!(int!(42), 42);
         assert_eq!(42, int!(42));
+
+        // ordering
+        assert!(1 > int!(0));
+        assert!(int!(1) > 0);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -501,6 +501,18 @@ int_op_impl!(Mul, mul, MulAssign, mul_assign);
 int_op_impl!(Div, div, DivAssign, div_assign);
 int_op_impl!(Rem, rem, RemAssign, rem_assign);
 
+impl PartialEq<i64> for Int {
+    fn eq(&self, other: &i64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<Int> for i64 {
+    fn eq(&self, other: &Int) -> bool {
+        *self == other.0
+    }
+}
+
 impl Neg for Int {
     type Output = Self;
 
@@ -674,5 +686,11 @@ mod tests {
         assert!(u32::try_from(Int(u32_max + 1)).is_err());
         assert!(u32::try_from(Int(-1)).is_err());
         assert!(u32::try_from(Int(-10)).is_err());
+    }
+
+    #[test]
+    fn comparing_int_to_i64() {
+        assert_eq!(int!(42), 42);
+        assert_eq!(42, int!(42));
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -488,9 +488,37 @@ macro_rules! int_op_impl {
             }
         }
 
+        impl $trait<i64> for Int {
+            type Output = Self;
+
+            fn $method(self, rhs: i64) -> Self {
+                Self::new_(<i64 as $trait>::$method(self.0, rhs))
+            }
+        }
+
+        impl $trait<Int> for i64 {
+            type Output = Self;
+
+            fn $method(self, rhs: Int) -> Self {
+                <i64 as $trait>::$method(self, rhs.0)
+            }
+        }
+
         impl $assign_trait for Int {
             fn $assign_method(&mut self, other: Self) {
                 self.assign_(<i64 as $trait>::$method(self.0, other.0));
+            }
+        }
+
+        impl $assign_trait<i64> for Int {
+            fn $assign_method(&mut self, other: i64) {
+                self.assign_(<i64 as $trait>::$method(self.0, other));
+            }
+        }
+
+        impl $assign_trait<Int> for i64 {
+            fn $assign_method(&mut self, other: Int) {
+                *self = <i64 as $trait>::$method(*self, other.0);
             }
         }
     };
@@ -710,5 +738,54 @@ mod tests {
         // ordering
         assert!(1 > int!(0));
         assert!(int!(1) > 0);
+    }
+
+    #[test]
+    fn operations_between_int_and_i64() {
+        assert_eq!(int!(1) + 2, int!(3));
+        assert_eq!(1 + int!(2), int!(3));
+
+        assert_eq!(int!(2) - 1, int!(1));
+        assert_eq!(2 - int!(1), int!(1));
+
+        assert_eq!(int!(3) * 2, int!(6));
+        assert_eq!(3 * int!(2), int!(6));
+
+        assert_eq!(int!(6) / 2, int!(3));
+        assert_eq!(6 / int!(2), int!(3));
+
+        assert_eq!(int!(5) % 2, int!(1));
+        assert_eq!(5 % int!(2), int!(1));
+    }
+
+    #[test]
+    fn assignment_operations_between_int_and_i64() {
+        let mut int = int!(1);
+        let mut primitive_int = 1;
+
+        int += 1;
+        primitive_int += int!(1);
+        assert_eq!(int, 2);
+        assert_eq!(int, primitive_int);
+
+        int -= -1;
+        primitive_int -= int!(-1);
+        assert_eq!(int, 3);
+        assert_eq!(int, primitive_int);
+
+        int *= 3;
+        primitive_int *= int!(3);
+        assert_eq!(int, 9);
+        assert_eq!(int, primitive_int);
+
+        int /= 3;
+        primitive_int /= int!(3);
+        assert_eq!(int, 3);
+        assert_eq!(int, primitive_int);
+
+        int %= 2;
+        primitive_int %= int!(2);
+        assert_eq!(int, 1);
+        assert_eq!(int, primitive_int);
     }
 }

--- a/src/int.rs
+++ b/src/int.rs
@@ -1,9 +1,9 @@
 use core::{
+    cmp::Ordering,
     convert::TryFrom,
     iter,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
-    cmp::Ordering,
 };
 
 #[cfg(feature = "serde")]

--- a/src/int.rs
+++ b/src/int.rs
@@ -3,8 +3,8 @@ use core::{
     iter,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
+    cmp::Ordering,
 };
-use std::cmp::Ordering;
 
 #[cfg(feature = "serde")]
 use serde::{

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -518,6 +518,18 @@ uint_op_impl!(Mul, mul, MulAssign, mul_assign);
 uint_op_impl!(Div, div, DivAssign, div_assign);
 uint_op_impl!(Rem, rem, RemAssign, rem_assign);
 
+impl PartialEq<u64> for UInt {
+    fn eq(&self, other: &u64) -> bool {
+        self.0 == *other
+    }
+}
+
+impl PartialEq<UInt> for u64 {
+    fn eq(&self, other: &UInt) -> bool {
+        *self == other.0
+    }
+}
+
 impl iter::Sum for UInt {
     fn sum<I>(iter: I) -> Self
     where
@@ -691,5 +703,11 @@ mod tests {
         assert_eq!(i32::try_from(UInt(i16_max + 1)), Ok((i16::MAX as i32) + 1));
         assert_eq!(i32::try_from(UInt(i32_max)), Ok(i32::MAX));
         assert!(i32::try_from(UInt(i32_max + 1)).is_err());
+    }
+
+    #[test]
+    fn comparing_uint_to_u64() {
+        assert_eq!(uint!(42), 42);
+        assert_eq!(42, uint!(42));
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -4,6 +4,7 @@ use core::{
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
 };
+use std::cmp::Ordering;
 
 #[cfg(feature = "serde")]
 use serde::{
@@ -530,6 +531,18 @@ impl PartialEq<UInt> for u64 {
     }
 }
 
+impl PartialOrd<u64> for UInt {
+    fn partial_cmp(&self, other: &u64) -> Option<Ordering> {
+        self.0.partial_cmp(other)
+    }
+}
+
+impl PartialOrd<UInt> for u64 {
+    fn partial_cmp(&self, other: &UInt) -> Option<Ordering> {
+        self.partial_cmp(&other.0)
+    }
+}
+
 impl iter::Sum for UInt {
     fn sum<I>(iter: I) -> Self
     where
@@ -707,7 +720,12 @@ mod tests {
 
     #[test]
     fn comparing_uint_to_u64() {
+        // equality
         assert_eq!(uint!(42), 42);
         assert_eq!(42, uint!(42));
+
+        // ordering
+        assert!(1 > int!(0));
+        assert!(int!(1) > 0);
     }
 }

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -3,8 +3,8 @@ use core::{
     iter,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
+    cmp::Ordering,
 };
-use std::cmp::Ordering;
 
 #[cfg(feature = "serde")]
 use serde::{

--- a/src/uint.rs
+++ b/src/uint.rs
@@ -1,9 +1,9 @@
 use core::{
+    cmp::Ordering,
     convert::TryFrom,
     iter,
     ops::{Add, AddAssign, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Sub, SubAssign},
     str::FromStr,
-    cmp::Ordering,
 };
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
This implements common operations with the underlying primitive integer types (`i64` for `Int` and `u64` for `UInt`) and the other way round. So for example `PartialEq<i64> for Int` and `PartialEq<Int> for i64`.

**Comparison:**
* `PartialEq`
* `PartialOrd`

**Arithmetik:**
* `Add`
* `Sub`
* `Mul`
* `Div`
* `Rem`

**Assigning Arithmetik:**
* `AddAssign`
* `SubAssign`
* `MulAssign`
* `DivAssign`
* `RemAssign`