### PR TITLE
Reduce macro MSRV by not using inline const expressions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 * Breaking: Allow values larger than 32 bit for `int!` and `uint!` macros
   This means that `i32`-suffixed and `u32`-suffixed literals are no longer accepcted
-* The minimum supported rust version is raised to 1.46, if you don't use the `int!` and `uint!` macros, or 1.79 if you do
   * The old macros can be replaced like follows: `int!(42)` -> `Int::from(42_i32)` etc.
+* The minimum supported rust version is raised to 1.46.
 * The `int!` and `uint!` macros now support arbitrary const expressions, not just literals
 * `Int::new` and `UInt::new` are now const
 

--- a/README.md
+++ b/README.md
@@ -23,8 +23,7 @@ obsolete in any way though, since there will still be lots of JS code using
 `Number`, and code in other languages that assumes its use.
 </small>
 
-This crate requires rustc >= 1.46 if you don't use the `int!` and `uint!` macros or
-rustc >=1.79 if you do.
+This crate requires rustc >= 1.46.
 
 This crate is `no_std`-compatible with `default-features = false`. This will
 disable the `std` feature, which at the time of writing will only omit the

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -2,28 +2,26 @@
 /// Checks at compile time that the expression is in a valid range.
 #[macro_export]
 macro_rules! int {
-    ($n:expr) => {
-        const {
-            match $crate::Int::new($n) {
-                Some(int) => int,
-                None => panic!("Number is outside the range of an Int"),
-            }
-        }
-    };
+    ($n:expr) => {{
+        const VALUE: $crate::Int = match $crate::Int::new($n) {
+            Some(int) => int,
+            None => panic!("Number is outside the range of an Int"),
+        };
+        VALUE
+    }};
 }
 
 /// Creates a `UInt` from a constant expression.
 /// Checks at compile time that the expression is in a valid range.
 #[macro_export]
 macro_rules! uint {
-    ($n:expr) => {
-        const {
-            match $crate::UInt::new($n) {
-                Some(int) => int,
-                None => panic!("Number is outside the range of a UInt"),
-            }
-        }
-    };
+    ($n:expr) => {{
+        const VALUE: $crate::UInt = match $crate::UInt::new($n) {
+            Some(int) => int,
+            None => panic!("Number is outside the range of an Int"),
+        };
+        VALUE
+    }};
 }
 
 macro_rules! fmt_impls {


### PR DESCRIPTION
As discussed in #30, this uses named const values instead of inline const expressions in order to not require Rust 1.79 just for the macros, bringing the MSRV back to a single value.

The downside is that this won't work with const generics, but that is an acceptable downside for the benefit of not having to maintain two MSRVs in my opinion.