### PR TITLE
Support Error impls without depending on std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ default-features = false
 [features]
 float_deserialize = ["serde"]
 default = ["std"]
+"rust_1.81" = []
 std = []
 
 [dev-dependencies]

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,11 @@ use core::{
     num::ParseIntError as StdParseIntError,
 };
 
+#[cfg(all(feature = "rust_1.81", not(feature = "std")))]
+use core::error::Error;
+#[cfg(feature = "std")]
+use std::error::Error;
+
 /// The error type returned when when parsing an integer fails.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParseIntError {
@@ -36,8 +41,8 @@ impl Display for ParseIntError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for ParseIntError {}
+#[cfg(any(feature = "rust_1.81", feature = "std"))]
+impl Error for ParseIntError {}
 
 /// The error type returned when a checked integral type conversion fails.
 #[derive(Clone)]
@@ -63,5 +68,5 @@ impl Debug for TryFromIntError {
     }
 }
 
-#[cfg(feature = "std")]
-impl std::error::Error for TryFromIntError {}
+#[cfg(any(feature = "rust_1.81", feature = "std"))]
+impl Error for TryFromIntError {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@
 //!   feature.
 //! * `std`: Enable `std::error::Error` implementations for `ParseIntError`, `TryFromIntError`.
 //!   Enabled by default.
+//! * `rust_1.81`: Enable `core::error::Error` implementations for `ParseIntError`,
+//!   `TryFromIntError`. Does nothing if the `std` feature is enabled.
 
 #![no_std]
 #![deny(missing_debug_implementations, missing_docs)]


### PR DESCRIPTION
… for versions of Rust where `core::error::Error` is stable.