### PR TITLE
Replace float_deserialize feature with deserialize_via_float method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,14 @@
 * Breaking: Allow values larger than 32 bit for `int!` and `uint!` macros
   This means that `i32`-suffixed and `u32`-suffixed literals are no longer accepcted
   * The old macros can be replaced like follows: `int!(42)` -> `Int::from(42_i32)` etc.
-* The minimum supported rust version is raised to 1.46.
-* The `int!` and `uint!` macros now support arbitrary const expressions, not just literals
-* `Int::new` and `UInt::new` are now const
 * Breaking: Serialization of `Int` and `UInt` now call the serialization of `i64` and `u64` directly instead of
   serializing them as newtype structs, emulating `#[serde(transparent)]`.
   This doesn't make a difference for `serde_json` for example, but it could make a difference for other serializers
+* Breaking: Remove the `float_deserialize` feature and replace it with the `(U)Int::deserialize_via_float` methods that
+  can be used with serde's `deserialize_with` attribute.
+* The `int!` and `uint!` macros now support arbitrary const expressions, not just literals
+* `Int::new` and `UInt::new` are now const
+* The minimum supported rust version is raised to 1.57.
 
 # 0.2.2
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ optional = true
 default-features = false
 
 [features]
-float_deserialize = ["serde"]
 default = ["std"]
 "rust_1.81" = []
 std = []

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ implementations of `std::error::Error` for `ParseIntError` and
 without the `std` feature.
 
 Deserialization can be routed through `f64` instead of `u64` with the
-`float_deserialize` feature. This will still not deserialize numbers with a
+`(U)Int::deserialize_via_float` methods. This will still not deserialize numbers with a
 non-zero fractional component. Please be aware that
 `serde_json` doesn't losslessly parse large floats with a fractional part by
 default (even if the fractional part is `.0`). To fix that, enable its 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,9 +28,6 @@
 //! * `serde`: Serialization and deserialization support via [serde](https://serde.rs). Disabled by
 //!   default. You can use `js_int` + `serde` in `#![no_std]` contexts if you use
 //!   `default-features = false` for both.
-//! * `float_deserialize`: Deserialize via `f64`, not via `u64`. If the input has a fraction,
-//!   deserialization will fail.
-//! * `lax_deserialize`: Like `float_deserialize`, but if the input has a fraction, it is
 //!   deserialized with the fractional part discarded.
 //!   Please be aware that `serde_json` doesn't losslessly parse large floats with a fractional part
 //!   by default (even if the fractional part is `.0`). To fix that, enable its `float_roundtrip`
@@ -59,7 +56,7 @@ pub use self::{
     uint::{UInt, MAX_SAFE_UINT},
 };
 
-#[cfg(feature = "float_deserialize")]
+#[cfg(feature = "serde")]
 #[inline(always)]
 pub(crate) fn is_acceptable_float(float: f64) -> bool {
     !float.is_nan() && float.fract() == 0.0


### PR DESCRIPTION
This replaces the `float_deserialize` feature with `Int::deserialize_via_float` and `UInt::deserialize_via_float` methods that can be used via `#[serde(deserialize_with = ...)]`.

This means that changing features will no longer silently change the behavior of the library.

* [x] implement
* [x] pass ci
* [x] documentation
* [x] update changelog