### PR TITLE
Fix MSRV of the macros to actually be 1.46

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -8,16 +8,18 @@ on:
 
 jobs:
   check:
-    name: Check
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: dtolnay/rust-toolchain@1.46
-    - name: Check (no default features)
-      run: cargo check --no-default-features
-    - name: Check (default features)
-      run: cargo check
-    - name: Check (serde)
-      run: cargo check --features serde
-    - name: Check (all features)
-      run: cargo check --all-features
+    - name: Run tests (no default features)
+      run: cargo test --no-default-features
+    - name: Run tests (default features)
+      run: cargo test
+    - name: Run tests (serde)
+      run: cargo test --features serde
+    - name: Run tests (all features)
+      run: cargo test --all-features
+    - name: Run tests (release build)
+      run: cargo test --release

--- a/.github/workflows/stable.yml
+++ b/.github/workflows/stable.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check:
-    name: Check
+    name: Test
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/js_int"
 keywords = ["integer", "no_std"]
 categories = ["no-std"]
+rust-version = "1.46.0"
 
 [dependencies.serde]
 version = "1.0"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,21 @@ macro_rules! int {
     ($n:expr) => {{
         const VALUE: $crate::Int = match $crate::Int::new($n) {
             Some(int) => int,
-            None => panic!("Number is outside the range of an Int"),
+            None => {
+                // Hack to emulate a panic in this case.
+                // Inspired by the [`static_assertions`](https://github.com/nvzqz/static-assertions) package.
+                // Improvements to be made with higher MSRVs:
+                // * 1.48: Replace the number comparison with `Option::is_none`
+                // * 1.57: Use `panic!()` directly.
+                // * 1.83: Replace manual `panic!()` with `Option::expect`
+                const _: [(); 0 - !{
+                    const ASSERT: bool = $n >= $crate::MIN_SAFE_INT && $n <= $crate::MAX_SAFE_INT;
+                    ASSERT
+                } as usize] = [];
+                // This loop should not run, but it produces a never type that keeps the match
+                // arms having the same type (since never conforms to any type)
+                loop {}
+            }
         };
         VALUE
     }};
@@ -18,7 +32,22 @@ macro_rules! uint {
     ($n:expr) => {{
         const VALUE: $crate::UInt = match $crate::UInt::new($n) {
             Some(int) => int,
-            None => panic!("Number is outside the range of an Int"),
+            None => {
+                // Hack to emulate a panic in this case.
+                // Inspired by the [`static_assertions`](https://github.com/nvzqz/static-assertions) package.
+                // Improvements to be made with higher MSRVs:
+                // * 1.48: Replace the number comparison with `Option::is_none`
+                // * 1.57: Use `panic!()` directly.
+                // * 1.83: Replace manual `panic!()` with `Option::expect`
+                #[allow(unknown_lints, unused_comparisons)]
+                const _: [(); 0 - !{
+                    const ASSERT: bool = $n <= $crate::MAX_SAFE_UINT;
+                    ASSERT
+                } as usize] = [];
+                // This loop should not run, but it produces a never type that keeps the match
+                // arms having the same type (since never conforms to any type)
+                loop {}
+            }
         };
         VALUE
     }};


### PR DESCRIPTION
Turns out that `panic!` is only stable in `const` contexts starting with Rust `1.57`. Initially I was going to introduce a dual MSRV again with `1.57` required for the macros, but then I remembered that there was a trick to get compile time assertions with previous versions of rust.

The code in the macros is far from elegant and doesn't produce great compiler errors, but it does work on `1.46`.

This change together with #41 also finally allows running the full tests on our MSRV.