### PR TITLE
Revert "Fix macros to work with rust 1.46"

### DIFF
--- a/.github/workflows/msrv.yml
+++ b/.github/workflows/msrv.yml
@@ -1,4 +1,4 @@
-name: Rust 1.46
+name: Rust 1.57
 
 on:
   push:
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - uses: dtolnay/rust-toolchain@1.46
+    - uses: dtolnay/rust-toolchain@1.57
     - name: Run tests (no default features)
       run: cargo test --no-default-features
     - name: Run tests (default features)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 repository = "https://github.com/ruma/js_int"
 keywords = ["integer", "no_std"]
 categories = ["no-std"]
-rust-version = "1.46.0"
+rust-version = "1.57.0"
 
 [dependencies.serde]
 version = "1.0"

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,21 +5,7 @@ macro_rules! int {
     ($n:expr) => {{
         const VALUE: $crate::Int = match $crate::Int::new($n) {
             Some(int) => int,
-            None => {
-                // Hack to emulate a panic in this case.
-                // Inspired by the [`static_assertions`](https://github.com/nvzqz/static-assertions) package.
-                // Improvements to be made with higher MSRVs:
-                // * 1.48: Replace the number comparison with `Option::is_none`
-                // * 1.57: Use `panic!()` directly.
-                // * 1.83: Replace manual `panic!()` with `Option::expect`
-                const _: [(); 0 - !{
-                    const ASSERT: bool = $n >= $crate::MIN_SAFE_INT && $n <= $crate::MAX_SAFE_INT;
-                    ASSERT
-                } as usize] = [];
-                // This loop should not run, but it produces a never type that keeps the match
-                // arms having the same type (since never conforms to any type)
-                loop {}
-            }
+            None => panic!("Number is outside the range of an Int"),
         };
         VALUE
     }};
@@ -32,22 +18,7 @@ macro_rules! uint {
     ($n:expr) => {{
         const VALUE: $crate::UInt = match $crate::UInt::new($n) {
             Some(int) => int,
-            None => {
-                // Hack to emulate a panic in this case.
-                // Inspired by the [`static_assertions`](https://github.com/nvzqz/static-assertions) package.
-                // Improvements to be made with higher MSRVs:
-                // * 1.48: Replace the number comparison with `Option::is_none`
-                // * 1.57: Use `panic!()` directly.
-                // * 1.83: Replace manual `panic!()` with `Option::expect`
-                #[allow(unknown_lints, unused_comparisons)]
-                const _: [(); 0 - !{
-                    const ASSERT: bool = $n <= $crate::MAX_SAFE_UINT;
-                    ASSERT
-                } as usize] = [];
-                // This loop should not run, but it produces a never type that keeps the match
-                // arms having the same type (since never conforms to any type)
-                loop {}
-            }
+            None => panic!("Number is outside the range of an Int"),
         };
         VALUE
     }};


### PR DESCRIPTION
This reverts commit 3aa5e3ec531575d98b6387749bdacd2848b8525a.

I want to change the `serde` dependency to be on the new `serde_core` crate. I don't want to have an implicit `serde_core` Cargo feature though, which means using `dep:` syntax for enabling the optional dependency, which requires Rust 1.60. May as well get the nicer panic message and simpler implementation for the macros then.

I'll probably ship this together with #39 as js_int v0.3.0.